### PR TITLE
Fix default trading pairs configuration

### DIFF
--- a/apps/api/config.py
+++ b/apps/api/config.py
@@ -1,7 +1,26 @@
 # apps/api/config.py
 
 import os
-from pydantic import BaseModel, Field
+from typing import Iterable, List, Optional, Union
+
+from pydantic import BaseModel, Field, field_validator
+
+DEFAULT_PAIRS = "BTC/USDT,ETH/USDT,BNB/USDT,ADA/USDT,SOL/USDT"
+
+def _coerce_pairs(value: Optional[Union[str, Iterable[str]]]) -> List[str]:
+    """Normalise pairs input from env/string/list into a clean list."""
+    if value is None:
+        return []
+    if isinstance(value, str):
+        items = value.split(",")
+    else:
+        items = list(value)
+    cleaned: List[str] = []
+    for item in items:
+        text = str(item).strip()
+        if text:
+            cleaned.append(text)
+    return cleaned
 
 class Settings(BaseModel):
     app_name: str = Field(default=os.getenv("APP_NAME", "Trader AI API"))
@@ -15,5 +34,16 @@ class Settings(BaseModel):
     api_prefix: str = Field(default=os.getenv("API_PREFIX", ""))
     default_page_size: int = Field(default=int(os.getenv("DEFAULT_PAGE_SIZE", "50")))
     max_page_size: int = Field(default=int(os.getenv("MAX_PAGE_SIZE", "500")))
+    pairs: List[str] = Field(
+        default_factory=lambda: _coerce_pairs(os.getenv("PAIRS", DEFAULT_PAIRS))
+    )
+
+    @field_validator("pairs", mode="before")
+    @classmethod
+    def _parse_pairs(cls, value: Optional[Union[str, Iterable[str]]]) -> List[str]:
+        parsed = _coerce_pairs(value)
+        if not parsed:
+            return _coerce_pairs(DEFAULT_PAIRS.split(","))
+        return parsed
 
 settings = Settings()

--- a/tests/test_config_pairs.py
+++ b/tests/test_config_pairs.py
@@ -1,0 +1,29 @@
+import importlib
+
+import apps.api.config as config_module
+
+
+def _reload_with_pairs(monkeypatch, value):
+    if value is None:
+        monkeypatch.delenv("PAIRS", raising=False)
+    else:
+        monkeypatch.setenv("PAIRS", value)
+    return importlib.reload(config_module)
+
+
+def test_settings_pairs_default(monkeypatch):
+    module = _reload_with_pairs(monkeypatch, None)
+    assert module.settings.pairs == [
+        "BTC/USDT",
+        "ETH/USDT",
+        "BNB/USDT",
+        "ADA/USDT",
+        "SOL/USDT",
+    ]
+
+
+def test_settings_pairs_custom(monkeypatch):
+    module = _reload_with_pairs(monkeypatch, "BTC/USDT , XRP/USDT ,")
+    assert module.settings.pairs == ["BTC/USDT", "XRP/USDT"]
+    # Restore defaults for other tests
+    _reload_with_pairs(monkeypatch, None)


### PR DESCRIPTION
## Summary
- add a default/fallback list of trading pairs to the API settings so services relying on settings.pairs work out of the box
- normalise the pairs configuration from env/input to avoid empty lists and trim whitespace
- cover the configuration behaviour with tests for both default and custom PAIRS values

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d8f34c3744832dbc630ca10af776af