### PR TITLE
Add signal engine pipeline with registry integration

### DIFF
--- a/apps/ml/signal_engine.py
+++ b/apps/ml/signal_engine.py
@@ -1,11 +1,19 @@
 import numpy as np
 import pandas as pd
-from typing import Dict, Optional, Tuple
+from typing import Dict, Optional, Tuple, Callable, Any
+from dataclasses import dataclass
 from datetime import datetime, timedelta
+from enum import Enum
 import logging
 import uuid
-from apps.api.db.models import RiskProfile, Side
+from sqlalchemy.orm import Session
+from sqlalchemy import and_
+
+from apps.api.db.models import RiskProfile, Side, OHLCV, MarketMetrics
 from apps.api.config import settings
+from apps.ml.features import FeatureEngineering
+from apps.ml.model_registry import ModelRegistry
+from apps.ml.models import EnsembleModel
 
 logger = logging.getLogger(__name__)
 
@@ -136,6 +144,506 @@ class SignalGenerator:
         }
 
         return signal
+
+    def _calculate_tp_sl(
+        self,
+        entry_price: float,
+        atr: float,
+        side: Side
+    ) -> Tuple[list, float]:
+        """
+        Calculate TP levels and SL using ATR-based approach.
+
+        Returns:
+            (tp_levels, sl_price)
+        """
+        atr_multiplier_sl = 1.5
+        atr_multiplier_tp1 = 1.0
+        atr_multiplier_tp2 = 2.0
+        atr_multiplier_tp3 = 3.0
+
+        if side == Side.LONG:
+            sl_price = entry_price - (atr * atr_multiplier_sl)
+            tp1 = entry_price + (atr * atr_multiplier_tp1)
+            tp2 = entry_price + (atr * atr_multiplier_tp2)
+            tp3 = entry_price + (atr * atr_multiplier_tp3)
+        else:  # SHORT
+            sl_price = entry_price + (atr * atr_multiplier_sl)
+            tp1 = entry_price - (atr * atr_multiplier_tp1)
+            tp2 = entry_price - (atr * atr_multiplier_tp2)
+            tp3 = entry_price - (atr * atr_multiplier_tp3)
+
+        return [tp1, tp2, tp3], sl_price
+
+    def _calculate_position_size(
+        self,
+        entry_price: float,
+        sl_price: float,
+        risk_profile: RiskProfile,
+        capital_usd: float,
+        leverage_cap: Optional[int] = None
+    ) -> Tuple[float, float, float]:
+        """
+        Calculate position sizing based on risk per trade.
+
+        Returns:
+            (leverage, position_size_usd, quantity)
+        """
+        # Risk parameters by profile
+        risk_params = {
+            RiskProfile.LOW: {
+                'risk_per_trade': settings.LOW_RISK_PER_TRADE,
+                'max_lev': settings.LOW_MAX_LEV
+            },
+            RiskProfile.MEDIUM: {
+                'risk_per_trade': settings.MED_RISK_PER_TRADE,
+                'max_lev': settings.MED_MAX_LEV
+            },
+            RiskProfile.HIGH: {
+                'risk_per_trade': settings.HIGH_RISK_PER_TRADE,
+                'max_lev': settings.HIGH_MAX_LEV
+            }
+        }
+
+        params = risk_params[risk_profile]
+        risk_per_trade = params['risk_per_trade']
+        max_leverage = leverage_cap if leverage_cap else params['max_lev']
+
+        # Calculate risk amount
+        risk_usd = capital_usd * risk_per_trade
+
+        # Calculate position size based on SL distance
+        sl_distance_pct = abs(entry_price - sl_price) / entry_price
+
+        if sl_distance_pct == 0:
+            logger.error("SL distance is zero, cannot calculate position size")
+            return 1.0, 100.0, 100.0 / entry_price
+
+        # Position size such that hitting SL loses exactly risk_usd
+        position_size_usd = risk_usd / sl_distance_pct
+
+        # Apply leverage constraint
+        max_position_size = capital_usd * max_leverage
+        position_size_usd = min(position_size_usd, max_position_size)
+
+        # Calculate actual leverage used
+        leverage = position_size_usd / capital_usd
+        leverage = min(leverage, max_leverage)
+
+        # Calculate quantity
+        quantity = position_size_usd / entry_price
+
+        return leverage, position_size_usd, quantity
+
+    def _calculate_expected_profit(
+        self,
+        entry_price: float,
+        tp_prices: list,
+        tp_pcts: list,
+        sl_price: float,
+        position_size_usd: float,
+        leverage: float,
+        side: Side
+    ) -> Tuple[float, float]:
+        """
+        Calculate expected net profit after all costs (fees, slippage, funding).
+
+        Assumes partial exits at TP1/TP2/TP3 with specified percentages.
+
+        Returns:
+            (expected_net_profit_pct, expected_net_profit_usd)
+        """
+        # Assume TP hit scenario (optimistic but realistic for filtering)
+        # Weighted average of TP levels
+        avg_exit_price = sum(tp * pct / 100 for tp, pct in zip(tp_prices, tp_pcts))
+
+        # Gross profit
+        if side == Side.LONG:
+            gross_profit_pct = (avg_exit_price - entry_price) / entry_price
+        else:
+            gross_profit_pct = (entry_price - avg_exit_price) / entry_price
+
+        gross_profit_usd = position_size_usd * gross_profit_pct
+
+        # Entry cost (assume maker order = lower fee)
+        entry_fee_usd = position_size_usd * (self.maker_fee_bps / 10000)
+        entry_slippage_usd = position_size_usd * (self.slippage_bps / 10000) * 0.5  # Reduced for maker
+
+        # Exit costs (assume 3 exits: TP1, TP2, TP3 - taker orders)
+        exit_size_total = position_size_usd
+        exit_fee_usd = exit_size_total * (self.taker_fee_bps / 10000)
+        exit_slippage_usd = exit_size_total * (self.slippage_bps / 10000)
+
+        # Funding cost (assume average hold time = 12 hours)
+        avg_hold_hours = 12
+        funding_cost_usd = position_size_usd * (self.funding_rate_hourly_bps / 10000) * avg_hold_hours
+
+        # Total costs
+        total_costs_usd = entry_fee_usd + entry_slippage_usd + exit_fee_usd + exit_slippage_usd + funding_cost_usd
+
+        # Net profit
+        net_profit_usd = gross_profit_usd - total_costs_usd
+        net_profit_pct = (net_profit_usd / position_size_usd) * 100
+
+        return net_profit_pct, net_profit_usd
+
+    def _calculate_liquidation_price(
+        self,
+        entry_price: float,
+        leverage: float,
+        side: Side
+    ) -> float:
+        """
+        Calculate liquidation price (simplified formula).
+
+        Liquidation occurs when loss = margin (1/leverage of position).
+        """
+        margin_ratio = 1 / leverage
+
+        if side == Side.LONG:
+            liq_price = entry_price * (1 - margin_ratio * 0.9)  # 90% of margin (maintenance margin buffer)
+        else:
+            liq_price = entry_price * (1 + margin_ratio * 0.9)
+
+        return liq_price
+
+    def _validate_liquidation(
+        self,
+        sl_price: float,
+        liq_price: float,
+        side: Side
+    ) -> bool:
+        """
+        Validate that liquidation price is sufficiently far from SL.
+        We want SL to trigger before liquidation.
+        """
+        if side == Side.LONG:
+            # liq_price should be below sl_price
+            return liq_price < sl_price * 0.95
+        else:
+            # liq_price should be above sl_price
+            return liq_price > sl_price * 1.05
+
+    def apply_trailing_stop(
+        self,
+        current_price: float,
+        entry_price: float,
+        current_sl: float,
+        tp1_price: float,
+        side: Side,
+        atr: float
+    ) -> float:
+        """
+        Apply trailing stop after TP1 is hit.
+
+        Returns:
+            New SL price
+        """
+        tp1_hit = (
+            (side == Side.LONG and current_price >= tp1_price) or
+            (side == Side.SHORT and current_price <= tp1_price)
+        )
+
+        if not tp1_hit:
+            return current_sl
+
+        # Move SL to breakeven + small buffer
+        trailing_distance = atr * 0.5
+
+        if side == Side.LONG:
+            new_sl = max(current_sl, entry_price + trailing_distance)
+            new_sl = max(new_sl, current_price - atr * 1.0)  # Trail below current price
+        else:
+            new_sl = min(current_sl, entry_price - trailing_distance)
+            new_sl = min(new_sl, current_price + atr * 1.0)
+
+        return new_sl
+
+
+@dataclass
+class SignalInferenceResult:
+    """Container holding signal inference outputs and metadata."""
+
+    signal: Optional[Dict]
+    model_info: Dict[str, Any]
+    risk_filters: Dict[str, bool]
+    inference_metadata: Dict[str, Any]
+    accepted: bool
+
+
+class SignalEngine:
+    """
+    High level signal generation pipeline that
+    1. Loads the currently deployed model from the registry
+    2. Prepares latest OHLCV features + ATR
+    3. Runs inference and applies risk filters before producing a trading signal.
+    """
+
+    def __init__(
+        self,
+        db: Session,
+        registry: Optional[ModelRegistry] = None,
+        signal_generator: Optional[SignalGenerator] = None,
+        model_factory: Optional[Callable[[], Any]] = None,
+        lookback_bars: int = 250,
+        max_spread_bps: float = 15.0,
+        min_volume: float = 1.0
+    ):
+        self.db = db
+        self.registry = registry or ModelRegistry()
+        self.signal_generator = signal_generator or SignalGenerator()
+        self.model_factory = model_factory or EnsembleModel
+        self.lookback_bars = lookback_bars
+        self.max_spread_bps = max_spread_bps
+        self.min_volume = min_volume
+        self.feature_engineering = FeatureEngineering()
+
+    def generate_for_deployment(
+        self,
+        symbol: str,
+        timeframe: str,
+        environment: str = "production",
+        risk_profile: RiskProfile = RiskProfile.MEDIUM,
+        capital_usd: float = 1000.0
+    ) -> Optional[SignalInferenceResult]:
+        """Generate signal for the current deployed model of a symbol/timeframe."""
+
+        deployment = self.registry.get_deployed_model(symbol, timeframe, environment)
+
+        if not deployment:
+            logger.warning(
+                "No deployed model found for %s %s in %s environment",
+                symbol,
+                timeframe,
+                environment
+            )
+            return None
+
+        try:
+            latest_snapshot = self._prepare_latest_snapshot(symbol, timeframe)
+        except ValueError as exc:
+            logger.error("Signal generation aborted: %s", exc)
+            return None
+
+        model = self._load_model(deployment)
+
+        feature_columns = self._determine_feature_columns(model, latest_snapshot['features'])
+        if not feature_columns:
+            raise ValueError("No numeric features available for inference")
+        inference_values = []
+        for column in feature_columns:
+            value = latest_snapshot['features'].get(column)
+            try:
+                inference_values.append(float(value))
+            except (TypeError, ValueError):
+                inference_values.append(0.0)
+
+        inference_df = pd.DataFrame([inference_values], columns=feature_columns)
+
+        probabilities = model.predict_proba(inference_df)
+        probability = float(probabilities[0]) if isinstance(probabilities, (list, np.ndarray, pd.Series)) else float(probabilities)
+
+        side = Side.LONG if probability >= 0.5 else Side.SHORT
+        confidence = probability if side == Side.LONG else 1.0 - probability
+
+        atr = float(latest_snapshot['atr'])
+        entry_price = float(latest_snapshot['close'])
+        volume = float(latest_snapshot['volume'])
+        spread_bps = float(latest_snapshot.get('spread_bps', 0.0))
+
+        risk_filters = {
+            'confidence': confidence >= settings.MIN_CONFIDENCE_THRESHOLD,
+            'atr': atr > 0,
+            'liquidity': volume >= self.min_volume,
+            'spread': spread_bps <= self.max_spread_bps,
+            'correlation': True,
+            'profit': False  # updated after generator run
+        }
+
+        inference_metadata = {
+            'probability': probability,
+            'confidence': confidence,
+            'side': side.value,
+            'environment': environment,
+            'timestamp': latest_snapshot['timestamp']
+        }
+
+        if not all(risk_filters[key] for key in ['confidence', 'atr', 'liquidity', 'spread']):
+            logger.info(
+                "Signal for %s %s rejected by pre-signal risk filters: %s",
+                symbol,
+                timeframe,
+                {k: v for k, v in risk_filters.items() if not v}
+            )
+            return SignalInferenceResult(
+                signal=None,
+                model_info=self._build_model_info(deployment),
+                risk_filters=risk_filters,
+                inference_metadata=inference_metadata,
+                accepted=False
+            )
+
+        leverage_cap = {
+            RiskProfile.LOW: settings.LOW_MAX_LEV,
+            RiskProfile.MEDIUM: settings.MED_MAX_LEV,
+            RiskProfile.HIGH: settings.HIGH_MAX_LEV
+        }[risk_profile]
+
+        signal = self.signal_generator.generate_signal(
+            symbol=symbol,
+            side=side,
+            entry_price=entry_price,
+            atr=atr,
+            risk_profile=risk_profile,
+            capital_usd=capital_usd,
+            confidence=confidence,
+            timestamp=latest_snapshot['timestamp'],
+            leverage_cap=leverage_cap
+        )
+
+        if not signal:
+            risk_filters['profit'] = False
+            logger.info("Signal for %s %s rejected by profit filter", symbol, timeframe)
+            return SignalInferenceResult(
+                signal=None,
+                model_info=self._build_model_info(deployment),
+                risk_filters=risk_filters,
+                inference_metadata=inference_metadata,
+                accepted=False
+            )
+
+        risk_filters['profit'] = True
+
+        signal['model_id'] = deployment.get('model_id')
+        signal['model_version'] = deployment.get('version')
+
+        return SignalInferenceResult(
+            signal=signal,
+            model_info=self._build_model_info(deployment),
+            risk_filters=risk_filters,
+            inference_metadata=inference_metadata,
+            accepted=True
+        )
+
+    def _prepare_latest_snapshot(self, symbol: str, timeframe: str) -> Dict[str, Any]:
+        """Fetch latest OHLCV data and compute features/ATR."""
+
+        timeframe_value = timeframe.value if isinstance(timeframe, Enum) else str(timeframe)
+
+        ohlcv_rows = (
+            self.db.query(OHLCV)
+            .filter(
+                and_(
+                    OHLCV.symbol == symbol,
+                    OHLCV.timeframe == timeframe_value,
+                    OHLCV.timestamp != None
+                )
+            )
+            .order_by(OHLCV.timestamp.desc())
+            .limit(self.lookback_bars)
+            .all()
+        )
+
+        if not ohlcv_rows:
+            raise ValueError(f"No OHLCV data available for {symbol} {timeframe}")
+
+        ohlcv_rows = list(reversed(ohlcv_rows))
+
+        df = pd.DataFrame([
+            {
+                'timestamp': row.timestamp,
+                'open': row.open,
+                'high': row.high,
+                'low': row.low,
+                'close': row.close,
+                'volume': row.volume
+            }
+            for row in ohlcv_rows
+        ])
+
+        market_metrics_row = (
+            self.db.query(MarketMetrics)
+            .filter(MarketMetrics.symbol == symbol)
+            .order_by(MarketMetrics.timestamp.desc())
+            .first()
+        )
+
+        market_metrics_df = pd.DataFrame([
+            {
+                'timestamp': market_metrics_row.timestamp,
+                'funding_rate': market_metrics_row.funding_rate,
+                'open_interest': market_metrics_row.open_interest,
+                'spread_bps': market_metrics_row.spread_bps,
+                'depth_imbalance': market_metrics_row.depth_imbalance,
+                'realized_volatility': market_metrics_row.realized_volatility
+            }
+        ]) if market_metrics_row else pd.DataFrame()
+
+        features_df = self.feature_engineering.compute_all_features(df, market_metrics=market_metrics_df)
+        features_df = features_df.fillna(method='ffill').fillna(method='bfill')
+
+        latest_row = features_df.iloc[-1]
+
+        atr = latest_row.get('atr_14')
+        if pd.isna(atr):
+            raise ValueError("ATR calculation returned NaN")
+
+        snapshot = {
+            'features': latest_row,
+            'atr': atr,
+            'close': latest_row.get('close'),
+            'volume': latest_row.get('volume', 0.0),
+            'spread_bps': latest_row.get('spread_bps', market_metrics_row.spread_bps if market_metrics_row else 0.0),
+            'timestamp': latest_row.get('timestamp') or df['timestamp'].iloc[-1]
+        }
+
+        if snapshot['close'] is None:
+            snapshot['close'] = df['close'].iloc[-1]
+
+        return snapshot
+
+    def _load_model(self, deployment: Dict[str, Any]):
+        """Instantiate and load model from deployment path."""
+
+        model_path = deployment.get('path')
+        if not model_path:
+            raise ValueError("Deployment missing model path")
+
+        model = self.model_factory()
+        model.load(model_path)
+        return model
+
+    @staticmethod
+    def _build_model_info(deployment: Dict[str, Any]) -> Dict[str, Any]:
+        return {
+            'model_id': deployment.get('model_id'),
+            'version': deployment.get('version'),
+            'path': deployment.get('path'),
+            'symbol': deployment.get('symbol'),
+            'timeframe': deployment.get('timeframe')
+        }
+
+    @staticmethod
+    def _determine_feature_columns(model: Any, latest_row: pd.Series) -> list:
+        """Determine feature columns expected by the model."""
+
+        if hasattr(model, 'feature_names') and model.feature_names:
+            return list(model.feature_names)
+
+        excluded_columns = {
+            'timestamp', 'open', 'high', 'low', 'close', 'volume',
+            'symbol', 'timeframe'
+        }
+
+        numeric_columns = []
+        for col in latest_row.index:
+            if col in excluded_columns:
+                continue
+            value = latest_row[col]
+            if isinstance(value, (int, float, np.number)) and not pd.isna(value):
+                numeric_columns.append(col)
+
+        return numeric_columns
 
     def _calculate_tp_sl(
         self,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,10 @@
+import os
+
+# Provide default environment variables required by the Settings model so that
+# unit tests can import modules without requiring a full .env configuration.
+os.environ.setdefault("DATABASE_URL", "postgresql://user:pass@localhost:5432/testdb")
+os.environ.setdefault("ASYNC_DATABASE_URL", "postgresql+asyncpg://user:pass@localhost:5432/testdb")
+os.environ.setdefault("REDIS_URL", "redis://localhost:6379/0")
+os.environ.setdefault("CELERY_BROKER_URL", "redis://localhost:6379/0")
+os.environ.setdefault("CELERY_RESULT_BACKEND", "redis://localhost:6379/1")
+os.environ.setdefault("SECRET_KEY", "test-secret-key")

--- a/tests/test_signal_engine_pipeline.py
+++ b/tests/test_signal_engine_pipeline.py
@@ -1,0 +1,222 @@
+from datetime import datetime, timedelta
+from types import SimpleNamespace
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from apps.api.config import settings
+from apps.api.db.base import Base
+from apps.api.db.models import (
+    OHLCV,
+    ModelRegistry as ModelRegistryRecord,
+    RiskProfile,
+    Side,
+    Signal,
+    SignalStatus,
+    TimeFrame
+)
+from apps.ml.signal_engine import SignalEngine
+from apps.ml.signal_engine import SignalGenerator
+from apps.ml.worker import generate_signals_task
+
+
+class DummyRegistry:
+    def __init__(self, deployment):
+        self._deployment = deployment
+
+    def get_deployed_model(self, symbol, timeframe, environment='production'):
+        return self._deployment
+
+
+class DummyModel:
+    def __init__(self, probability=0.8):
+        self.probability = probability
+        self.feature_names = ['ema_21', 'rsi_14', 'atr_14', 'volume']
+
+    def load(self, path):
+        return self
+
+    def predict_proba(self, X):
+        return [self.probability for _ in range(len(X))]
+
+
+def create_sqlite_session():
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    return sessionmaker(bind=engine), engine
+
+
+def insert_mock_ohlcv(session, symbol="BTC/USDT", rows=120):
+    base_ts = datetime.utcnow() - timedelta(minutes=rows * 15)
+
+    for idx in range(rows):
+        ts = base_ts + timedelta(minutes=15 * idx)
+        session.add(
+            OHLCV(
+                symbol=symbol,
+                timeframe=TimeFrame.M15,
+                timestamp=ts,
+                open=50000 + idx,
+                high=50000 + idx + 800,
+                low=50000 + idx - 800,
+                close=50000 + idx + 120,
+                volume=150 + idx
+            )
+        )
+
+    session.commit()
+
+
+def test_signal_engine_pipeline_generates_profitable_signal():
+    SessionLocal, engine = create_sqlite_session()
+    session = SessionLocal()
+    insert_mock_ohlcv(session)
+
+    deployment = {
+        'model_id': 'model123',
+        'version': 'v1',
+        'path': 'unused',
+        'symbol': 'BTC/USDT',
+        'timeframe': '15m'
+    }
+
+    engine_service = SignalEngine(
+        db=session,
+        registry=DummyRegistry(deployment),
+        model_factory=lambda: DummyModel(0.8),
+        lookback_bars=90
+    )
+
+    result = engine_service.generate_for_deployment(
+        symbol='BTC/USDT',
+        timeframe='15m',
+        risk_profile=RiskProfile.MEDIUM,
+        capital_usd=1000.0
+    )
+
+    assert result is not None
+    assert result.accepted is True
+    assert result.signal['expected_net_profit_pct'] >= settings.MIN_NET_PROFIT_PCT
+    assert result.inference_metadata['confidence'] == pytest.approx(0.8)
+
+    session.close()
+    engine.dispose()
+
+
+def test_generate_signals_task_returns_statistics(monkeypatch):
+    SessionLocal, engine = create_sqlite_session()
+    session = SessionLocal()
+    insert_mock_ohlcv(session)
+
+    # Seed registry table to satisfy FK constraints if enabled
+    registry_record = ModelRegistryRecord(
+        model_id='model123',
+        symbol='BTC/USDT',
+        timeframe=TimeFrame.M15,
+        model_type='ensemble',
+        version='v1',
+        train_start=datetime.utcnow() - timedelta(days=200),
+        train_end=datetime.utcnow() - timedelta(days=60),
+        oos_start=datetime.utcnow() - timedelta(days=60),
+        oos_end=datetime.utcnow() - timedelta(days=1),
+        hyperparameters={}
+    )
+    session.add(registry_record)
+    session.commit()
+    session.close()
+
+    def session_factory():
+        return SessionLocal()
+
+    monkeypatch.setattr('apps.ml.worker.SessionLocal', session_factory)
+
+    class StubRegistry:
+        def __init__(self):
+            self.index = {
+                'deployments': {
+                    'BTC_USDT_15m_production': {
+                        'symbol': 'BTC/USDT',
+                        'timeframe': '15m',
+                        'environment': 'production',
+                        'model_id': 'model123',
+                        'version': 'v1',
+                        'path': 'unused'
+                    }
+                }
+            }
+
+        def get_deployed_model(self, symbol, timeframe, environment='production'):
+            return {
+                'symbol': symbol,
+                'timeframe': timeframe,
+                'environment': environment,
+                'model_id': 'model123',
+                'version': 'v1',
+                'path': 'unused'
+            }
+
+    generator = SignalGenerator()
+
+    class StubSignalEngine:
+        def __init__(self, db, registry=None, **kwargs):
+            self.db = db
+            self.registry = registry
+
+        def generate_for_deployment(self, symbol, timeframe, environment='production', **kwargs):
+            timestamp = datetime.utcnow()
+            signal = generator.generate_signal(
+                symbol=symbol,
+                side=Side.LONG,
+                entry_price=52000.0,
+                atr=1500.0,
+                risk_profile=RiskProfile.MEDIUM,
+                capital_usd=1000.0,
+                confidence=0.7,
+                timestamp=timestamp
+            )
+
+            if not signal:
+                return None
+
+            signal['model_id'] = 'model123'
+            signal['model_version'] = 'v1'
+
+            return SimpleNamespace(
+                signal=signal,
+                model_info={
+                    'model_id': 'model123',
+                    'version': 'v1',
+                    'path': 'unused'
+                },
+                risk_filters={'spread': True, 'liquidity': True, 'profit': True, 'correlation': True, 'confidence': True},
+                inference_metadata={'probability': 0.7, 'confidence': 0.7, 'side': 'long', 'timestamp': timestamp},
+                accepted=True
+            )
+
+    monkeypatch.setattr('apps.ml.worker.ModelRegistry', lambda: StubRegistry())
+    monkeypatch.setattr('apps.ml.worker.SignalEngine', StubSignalEngine)
+
+    broadcasts = []
+
+    async def fake_broadcast(message):
+        broadcasts.append(message)
+
+    monkeypatch.setattr('apps.api.main.manager.broadcast', fake_broadcast)
+
+    result = generate_signals_task.run()
+
+    assert result['signals_generated'] == 1
+    assert result['broadcasts'] == 1
+    assert result['metrics']['average_confidence'] == pytest.approx(0.7)
+
+    session = SessionLocal()
+    stored_signals = session.query(Signal).all()
+    assert len(stored_signals) == 1
+    assert stored_signals[0].status == SignalStatus.ACTIVE
+
+    assert len(broadcasts) == 1
+    assert broadcasts[0]['type'] == 'signal.created'
+
+    session.close()
+    engine.dispose()


### PR DESCRIPTION
## Summary
- add a SignalEngine service that loads deployed models, prepares latest OHLCV features/ATR, evaluates risk filters, and produces SignalGenerator outputs
- extend the generate_signals_task to run the end-to-end inference pipeline, persist Signal rows, emit websocket broadcasts, and aggregate task metrics
- add test scaffolding and integration tests ensuring profitable signal creation and celery task statistics, including default test settings

## Testing
- pytest tests/test_signal_engine_pipeline.py

------
https://chatgpt.com/codex/tasks/task_e_68e23a92f324832dad228ad624802af5