### PR TITLE
Allow active signals in live API

### DIFF
--- a/apps/api/routers/signals.py
+++ b/apps/api/routers/signals.py
@@ -93,7 +93,7 @@ async def get_live_signals(
     """
     query = select(Signal).where(
         and_(
-            Signal.status == SignalStatus.PENDING,
+            Signal.status.in_([SignalStatus.PENDING, SignalStatus.ACTIVE]),
             Signal.valid_until > datetime.utcnow(),
             Signal.passed_profit_filter == True
         )


### PR DESCRIPTION
## Summary
- allow the live signals endpoint to return both pending and active signals

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e273c4cc34832d9b1b3654ba3b1ca6