### PR TITLE
Log deployment inference batches to performance tracker

### DIFF
--- a/apps/api/config.py
+++ b/apps/api/config.py
@@ -32,6 +32,8 @@ class Settings(BaseSettings):
     MIN_CONFIDENCE_THRESHOLD: float = 0.55
     MIN_NET_PROFIT_PCT: float = 2.0
     DEFAULT_LOOKBACK_YEARS: int = 4
+    MODEL_REGISTRY_DIR: str = "./model_registry"
+    PERFORMANCE_TRACKING_DIR: str = "./performance_tracking"
 
     # Costs
     MAKER_FEE_BPS: float = 2.0

--- a/apps/ml/model_registry.py
+++ b/apps/ml/model_registry.py
@@ -5,6 +5,8 @@ from pathlib import Path
 from typing import Dict, List, Optional
 import logging
 
+from apps.api.config import settings
+
 logger = logging.getLogger(__name__)
 
 
@@ -14,8 +16,8 @@ class ModelRegistry:
     Tracks model performance, metadata, and enables model promotion/rollback.
     """
 
-    def __init__(self, registry_dir: str = "./model_registry"):
-        self.registry_dir = Path(registry_dir)
+    def __init__(self, registry_dir: Optional[str] = None):
+        self.registry_dir = Path(registry_dir or settings.MODEL_REGISTRY_DIR)
         self.registry_dir.mkdir(parents=True, exist_ok=True)
         self.index_file = self.registry_dir / "index.json"
         self._load_index()

--- a/apps/ml/performance_tracker.py
+++ b/apps/ml/performance_tracker.py
@@ -6,6 +6,8 @@ from pathlib import Path
 import json
 import logging
 
+from apps.api.config import settings
+
 logger = logging.getLogger(__name__)
 
 
@@ -15,8 +17,8 @@ class PerformanceTracker:
     Monitor for degradation, drift, and generate performance reports.
     """
 
-    def __init__(self, tracking_dir: str = "./performance_tracking"):
-        self.tracking_dir = Path(tracking_dir)
+    def __init__(self, tracking_dir: Optional[str] = None):
+        self.tracking_dir = Path(tracking_dir or settings.PERFORMANCE_TRACKING_DIR)
         self.tracking_dir.mkdir(parents=True, exist_ok=True)
 
     def log_prediction_batch(

--- a/apps/ml/signal_engine.py
+++ b/apps/ml/signal_engine.py
@@ -14,6 +14,7 @@ from apps.api.config import settings
 from apps.ml.features import FeatureEngineering
 from apps.ml.model_registry import ModelRegistry
 from apps.ml.models import EnsembleModel
+from apps.ml.performance_tracker import PerformanceTracker
 
 logger = logging.getLogger(__name__)
 
@@ -385,18 +386,22 @@ class SignalEngine:
         registry: Optional[ModelRegistry] = None,
         signal_generator: Optional[SignalGenerator] = None,
         model_factory: Optional[Callable[[], Any]] = None,
+        performance_tracker: Optional[PerformanceTracker] = None,
         lookback_bars: int = 250,
         max_spread_bps: float = 15.0,
         min_volume: float = 1.0
     ):
         self.db = db
-        self.registry = registry or ModelRegistry()
+        self.registry = registry or ModelRegistry(registry_dir=settings.MODEL_REGISTRY_DIR)
         self.signal_generator = signal_generator or SignalGenerator()
         self.model_factory = model_factory or EnsembleModel
         self.lookback_bars = lookback_bars
         self.max_spread_bps = max_spread_bps
         self.min_volume = min_volume
         self.feature_engineering = FeatureEngineering()
+        self.performance_tracker = performance_tracker or PerformanceTracker(
+            tracking_dir=settings.PERFORMANCE_TRACKING_DIR
+        )
 
     def generate_for_deployment(
         self,
@@ -468,6 +473,38 @@ class SignalEngine:
             'environment': environment,
             'timestamp': latest_snapshot['timestamp']
         }
+
+        prediction_record = inference_df.copy()
+        prediction_record['probability'] = probability
+        prediction_record['confidence'] = confidence
+        prediction_record['prediction'] = 1 if side == Side.LONG else 0
+        prediction_record['side'] = side.value
+        prediction_record['timestamp'] = pd.to_datetime(latest_snapshot['timestamp'])
+
+        tracking_metadata = {
+            **inference_metadata,
+            'risk_profile': risk_profile.value,
+            'capital_usd': capital_usd,
+            'model_version': deployment.get('version')
+        }
+
+        model_id = deployment.get('model_id')
+
+        try:
+            self.performance_tracker.log_prediction_batch(
+                model_id=model_id or "unknown",
+                symbol=symbol,
+                timeframe=timeframe,
+                predictions=prediction_record,
+                metadata=tracking_metadata
+            )
+        except Exception:
+            logger.exception(
+                "Failed to log prediction batch for %s %s in %s",
+                symbol,
+                timeframe,
+                environment
+            )
 
         if not all(risk_filters[key] for key in ['confidence', 'atr', 'liquidity', 'spread']):
             logger.info(

--- a/tests/test_signal_engine_pipeline.py
+++ b/tests/test_signal_engine_pipeline.py
@@ -1,5 +1,6 @@
 from datetime import datetime, timedelta
 from types import SimpleNamespace
+from unittest.mock import MagicMock
 
 import pytest
 from sqlalchemy import create_engine
@@ -99,6 +100,61 @@ def test_signal_engine_pipeline_generates_profitable_signal():
     assert result.accepted is True
     assert result.signal['expected_net_profit_pct'] >= settings.MIN_NET_PROFIT_PCT
     assert result.inference_metadata['confidence'] == pytest.approx(0.8)
+
+    session.close()
+    engine.dispose()
+
+
+def test_signal_engine_logs_prediction_batch_metadata():
+    SessionLocal, engine = create_sqlite_session()
+    session = SessionLocal()
+    insert_mock_ohlcv(session)
+
+    deployment = {
+        'model_id': 'model123',
+        'version': 'v1',
+        'path': 'unused',
+        'symbol': 'BTC/USDT',
+        'timeframe': '15m'
+    }
+
+    tracker_mock = MagicMock()
+
+    engine_service = SignalEngine(
+        db=session,
+        registry=DummyRegistry(deployment),
+        model_factory=lambda: DummyModel(0.65),
+        performance_tracker=tracker_mock,
+        lookback_bars=90
+    )
+
+    result = engine_service.generate_for_deployment(
+        symbol='BTC/USDT',
+        timeframe='15m',
+        risk_profile=RiskProfile.MEDIUM,
+        capital_usd=1500.0
+    )
+
+    assert result is not None
+    tracker_mock.log_prediction_batch.assert_called_once()
+    _, kwargs = tracker_mock.log_prediction_batch.call_args
+
+    assert kwargs['model_id'] == deployment['model_id']
+    assert kwargs['symbol'] == 'BTC/USDT'
+    assert kwargs['timeframe'] == '15m'
+
+    predictions_df = kwargs['predictions']
+    expected_columns = {'ema_21', 'rsi_14', 'atr_14', 'volume', 'probability', 'confidence', 'prediction', 'side', 'timestamp'}
+    assert expected_columns.issubset(set(predictions_df.columns))
+    assert len(predictions_df) == 1
+    assert predictions_df['probability'].iloc[0] == pytest.approx(0.65)
+    assert predictions_df['prediction'].iloc[0] in (0, 1)
+
+    metadata = kwargs['metadata']
+    assert metadata['environment'] == 'production'
+    assert metadata['risk_profile'] == RiskProfile.MEDIUM.value
+    assert metadata['capital_usd'] == pytest.approx(1500.0)
+    assert metadata['model_version'] == deployment['version']
 
     session.close()
     engine.dispose()


### PR DESCRIPTION
## Summary
- add configurable paths for the model registry and performance tracking directories
- ensure the model registry, performance tracker, and signal engine use the configured directories
- log deployment inference rows and metadata to the performance tracker and cover the behaviour with a unit test

## Testing
- pytest tests/test_signal_engine_pipeline.py

------
https://chatgpt.com/codex/tasks/task_e_68e27b4ed714832dae6ff8fbbd9d45d8