### PR TITLE
Add cached system analytics endpoints and admin charts

### DIFF
--- a/apps/api/cache.py
+++ b/apps/api/cache.py
@@ -1,0 +1,55 @@
+import json
+import logging
+from typing import Any, Optional
+
+from redis import Redis
+
+from apps.api.config import settings
+
+logger = logging.getLogger(__name__)
+
+_redis_client: Optional[Redis] = None
+
+
+def get_redis_client() -> Optional[Redis]:
+    global _redis_client
+    if _redis_client is not None:
+        return _redis_client
+
+    try:
+        client = Redis.from_url(str(settings.REDIS_URL), decode_responses=True)
+        # Validate connection eagerly to avoid using an unavailable backend
+        client.ping()
+        _redis_client = client
+    except Exception as exc:  # pragma: no cover - connection failures are logged
+        logger.warning("Redis cache unavailable: %s", exc)
+        _redis_client = None
+
+    return _redis_client
+
+
+def get_cached_json(key: str) -> Optional[Any]:
+    client = get_redis_client()
+    if client is None:
+        return None
+
+    try:
+        cached = client.get(key)
+        if cached is None:
+            return None
+        return json.loads(cached)
+    except Exception as exc:  # pragma: no cover - we fall back to live query
+        logger.warning("Failed to read cache key %s: %s", key, exc)
+        return None
+
+
+def set_cached_json(key: str, value: Any, ttl_seconds: int) -> None:
+    client = get_redis_client()
+    if client is None:
+        return
+
+    try:
+        payload = json.dumps(value)
+        client.setex(key, ttl_seconds, payload)
+    except Exception as exc:  # pragma: no cover - cache failures are non-fatal
+        logger.warning("Failed to set cache key %s: %s", key, exc)

--- a/apps/web/components/SystemAnalytics.tsx
+++ b/apps/web/components/SystemAnalytics.tsx
@@ -1,0 +1,196 @@
+import { useMemo } from 'react'
+import {
+  Area,
+  AreaChart,
+  CartesianGrid,
+  Legend,
+  Line,
+  LineChart,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from 'recharts'
+
+export interface AggregatedPnlPoint {
+  date: string
+  risk_profile: string
+  net_pnl_usd: number
+  avg_net_pnl_pct?: number | null
+  trade_count: number
+}
+
+export interface AggregatedExposurePoint {
+  date: string
+  risk_profile: string
+  exposure_usd: number
+}
+
+const RISK_PROFILE_ORDER: string[] = ['low', 'medium', 'high']
+const RISK_PROFILE_LABELS: Record<string, string> = {
+  low: 'Low Risk',
+  medium: 'Medium Risk',
+  high: 'High Risk',
+}
+const RISK_PROFILE_COLORS: Record<string, string> = {
+  low: '#38bdf8',
+  medium: '#a78bfa',
+  high: '#f97316',
+}
+
+type PivotedDatum = Record<string, number | string>
+
+type PivotKey = 'net_pnl_usd' | 'exposure_usd'
+
+const pivotSeriesByDate = <T extends { date: string; risk_profile: string }>(
+  series: T[],
+  valueKey: PivotKey,
+): PivotedDatum[] => {
+  const map = new Map<string, PivotedDatum>()
+
+  series.forEach((point: any) => {
+    const isoDate = point.date ? point.date.slice(0, 10) : ''
+    if (!isoDate) {
+      return
+    }
+
+    const current = map.get(isoDate) ?? { date: isoDate }
+    current[point.risk_profile] = Number(point[valueKey] ?? 0)
+    map.set(isoDate, current)
+  })
+
+  const result = Array.from(map.values()).map((entry) => {
+    RISK_PROFILE_ORDER.forEach((profile) => {
+      if (entry[profile] === undefined) {
+        entry[profile] = 0
+      }
+    })
+    return entry
+  })
+
+  result.sort((a, b) => String(a.date).localeCompare(String(b.date)))
+
+  return result
+}
+
+interface SystemAnalyticsProps {
+  pnl: AggregatedPnlPoint[]
+  exposure: AggregatedExposurePoint[]
+  loading?: boolean
+}
+
+const EmptyState = ({ loading }: { loading?: boolean }) => (
+  <div className="flex h-full items-center justify-center text-sm text-gray-400">
+    {loading ? 'Loading analytics…' : 'No data available yet'}
+  </div>
+)
+
+export default function SystemAnalytics({ pnl, exposure, loading }: SystemAnalyticsProps) {
+  const pnlChartData = useMemo(() => pivotSeriesByDate(pnl, 'net_pnl_usd'), [pnl])
+  const exposureChartData = useMemo(
+    () => pivotSeriesByDate(exposure, 'exposure_usd'),
+    [exposure],
+  )
+
+  return (
+    <div className="bg-gray-800 rounded-lg p-6 mb-8">
+      <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <h2 className="text-2xl font-bold">System Analytics</h2>
+          <p className="text-sm text-gray-400">
+            Daily profit &amp; exposure aggregated by risk profile to monitor portfolio health.
+          </p>
+        </div>
+      </div>
+
+      <div className="mt-6 grid gap-6 lg:grid-cols-2">
+        <div className="rounded-lg bg-gray-900 p-4 shadow">
+          <div className="mb-3 flex items-center justify-between">
+            <h3 className="text-lg font-semibold text-blue-200">Net PnL (USD)</h3>
+            <span className="text-xs uppercase tracking-wide text-gray-500">Daily</span>
+          </div>
+          <div className="h-64">
+            {pnlChartData.length === 0 ? (
+              <EmptyState loading={loading} />
+            ) : (
+              <ResponsiveContainer>
+                <LineChart data={pnlChartData}>
+                  <CartesianGrid strokeDasharray="3 3" stroke="#1f2937" />
+                  <XAxis dataKey="date" stroke="#9ca3af" fontSize={12} tickLine={false} />
+                  <YAxis stroke="#9ca3af" fontSize={12} tickLine={false} width={80} />
+                  <Tooltip
+                    contentStyle={{ backgroundColor: '#111827', borderRadius: '0.5rem', border: '1px solid #1f2937' }}
+                    formatter={(value: number, name: string) => [value.toFixed(2), RISK_PROFILE_LABELS[name] ?? name]}
+                  />
+                  <Legend formatter={(value) => RISK_PROFILE_LABELS[value] ?? value} />
+                  {RISK_PROFILE_ORDER.map((profile) => (
+                    <Line
+                      key={profile}
+                      type="monotone"
+                      dataKey={profile}
+                      stroke={RISK_PROFILE_COLORS[profile]}
+                      strokeWidth={2}
+                      dot={false}
+                      name={profile}
+                    />
+                  ))}
+                </LineChart>
+              </ResponsiveContainer>
+            )}
+          </div>
+        </div>
+
+        <div className="rounded-lg bg-gray-900 p-4 shadow">
+          <div className="mb-3 flex items-center justify-between">
+            <h3 className="text-lg font-semibold text-purple-200">Capital Exposure (USD)</h3>
+            <span className="text-xs uppercase tracking-wide text-gray-500">Daily</span>
+          </div>
+          <div className="h-64">
+            {exposureChartData.length === 0 ? (
+              <EmptyState loading={loading} />
+            ) : (
+              <ResponsiveContainer>
+                <AreaChart data={exposureChartData}>
+                  <defs>
+                    {RISK_PROFILE_ORDER.map((profile) => (
+                      <linearGradient
+                        key={profile}
+                        id={`color-${profile}`}
+                        x1="0"
+                        y1="0"
+                        x2="0"
+                        y2="1"
+                      >
+                        <stop offset="5%" stopColor={RISK_PROFILE_COLORS[profile]} stopOpacity={0.6} />
+                        <stop offset="95%" stopColor={RISK_PROFILE_COLORS[profile]} stopOpacity={0.05} />
+                      </linearGradient>
+                    ))}
+                  </defs>
+                  <CartesianGrid strokeDasharray="3 3" stroke="#1f2937" />
+                  <XAxis dataKey="date" stroke="#9ca3af" fontSize={12} tickLine={false} />
+                  <YAxis stroke="#9ca3af" fontSize={12} tickLine={false} width={80} />
+                  <Tooltip
+                    contentStyle={{ backgroundColor: '#111827', borderRadius: '0.5rem', border: '1px solid #1f2937' }}
+                    formatter={(value: number, name: string) => [value.toFixed(2), RISK_PROFILE_LABELS[name] ?? name]}
+                  />
+                  <Legend formatter={(value) => RISK_PROFILE_LABELS[value] ?? value} />
+                  {RISK_PROFILE_ORDER.map((profile) => (
+                    <Area
+                      key={profile}
+                      type="monotone"
+                      dataKey={profile}
+                      stroke={RISK_PROFILE_COLORS[profile]}
+                      fill={`url(#color-${profile})`}
+                      fillOpacity={1}
+                      name={profile}
+                    />
+                  ))}
+                </AreaChart>
+              </ResponsiveContainer>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/tests/test_system_aggregations.py
+++ b/tests/test_system_aggregations.py
@@ -1,0 +1,209 @@
+import pytest
+from datetime import datetime, timedelta
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session, sessionmaker
+
+from apps.api import cache
+from apps.api.db.models import Base, RiskProfile, Side, Signal, TradeResult
+from apps.api.routers import system
+from apps.api.routers.system import ANALYTICS_CACHE_TTL_SECONDS
+
+
+@pytest.fixture()
+def db_session() -> Session:
+    engine = create_engine("sqlite:///:memory:", connect_args={"check_same_thread": False})
+    Base.metadata.create_all(bind=engine)
+    TestingSessionLocal = sessionmaker(bind=engine)
+    session = TestingSessionLocal()
+    try:
+        yield session
+    finally:
+        session.close()
+        Base.metadata.drop_all(bind=engine)
+        engine.dispose()
+
+
+def _create_signal_with_result(
+    session: Session,
+    *,
+    signal_id: str,
+    risk_profile: RiskProfile,
+    closed_at: datetime,
+    net_pnl_usd: float,
+    net_pnl_pct: float,
+    position_size_usd: float,
+) -> None:
+    timestamp = closed_at - timedelta(hours=1)
+    signal = Signal(
+        signal_id=signal_id,
+        symbol="BTC/USDT",
+        side=Side.LONG,
+        entry_price=100.0,
+        timestamp=timestamp,
+        tp1_price=110.0,
+        tp2_price=120.0,
+        tp3_price=130.0,
+        sl_price=90.0,
+        leverage=2.0,
+        position_size_usd=position_size_usd,
+        quantity=1.0,
+        expected_net_profit_pct=5.0,
+        expected_net_profit_usd=5.0,
+        valid_until=timestamp + timedelta(hours=4),
+        risk_profile=risk_profile,
+    )
+    session.add(signal)
+
+    trade_result = TradeResult(
+        signal_id=signal_id,
+        net_pnl_usd=net_pnl_usd,
+        net_pnl_pct=net_pnl_pct,
+        closed_at=closed_at,
+    )
+    session.add(trade_result)
+
+    session.commit()
+
+
+@pytest.mark.asyncio
+async def test_get_system_pnl_aggregation_groups_by_day_and_profile(monkeypatch, db_session: Session):
+    monkeypatch.setattr(cache, "get_cached_json", lambda key: None)
+    stored_cache = {}
+
+    def _fake_set(key: str, value, ttl: int) -> None:
+        stored_cache[key] = {"value": value, "ttl": ttl}
+
+    monkeypatch.setattr(cache, "set_cached_json", _fake_set)
+
+    base_date = datetime(2024, 1, 1, 12, 0, 0)
+    _create_signal_with_result(
+        db_session,
+        signal_id="sig-low-1",
+        risk_profile=RiskProfile.LOW,
+        closed_at=base_date,
+        net_pnl_usd=150.0,
+        net_pnl_pct=3.0,
+        position_size_usd=1000.0,
+    )
+    _create_signal_with_result(
+        db_session,
+        signal_id="sig-low-2",
+        risk_profile=RiskProfile.LOW,
+        closed_at=base_date + timedelta(hours=2),
+        net_pnl_usd=50.0,
+        net_pnl_pct=1.0,
+        position_size_usd=800.0,
+    )
+    _create_signal_with_result(
+        db_session,
+        signal_id="sig-med-1",
+        risk_profile=RiskProfile.MEDIUM,
+        closed_at=base_date,
+        net_pnl_usd=-20.0,
+        net_pnl_pct=-0.5,
+        position_size_usd=1200.0,
+    )
+    _create_signal_with_result(
+        db_session,
+        signal_id="sig-high-1",
+        risk_profile=RiskProfile.HIGH,
+        closed_at=base_date + timedelta(days=1),
+        net_pnl_usd=200.0,
+        net_pnl_pct=4.0,
+        position_size_usd=1500.0,
+    )
+
+    response = await system.get_system_pnl(db=db_session)
+
+    assert [r.risk_profile for r in response] == [
+        RiskProfile.LOW,
+        RiskProfile.MEDIUM,
+        RiskProfile.HIGH,
+    ]
+    assert response[0].date.isoformat() == "2024-01-01"
+    assert response[0].net_pnl_usd == pytest.approx(200.0)
+    assert response[0].trade_count == 2
+    assert response[1].net_pnl_usd == pytest.approx(-20.0)
+    assert response[2].date.isoformat() == "2024-01-02"
+    assert stored_cache["system:pnl"]["ttl"] == ANALYTICS_CACHE_TTL_SECONDS
+
+
+@pytest.mark.asyncio
+async def test_get_system_exposure_aggregation_and_cache(monkeypatch, db_session: Session):
+    monkeypatch.setattr(cache, "get_cached_json", lambda key: None)
+    stored_cache = {}
+
+    def _fake_set(key: str, value, ttl: int) -> None:
+        stored_cache[key] = {"value": value, "ttl": ttl}
+
+    monkeypatch.setattr(cache, "set_cached_json", _fake_set)
+
+    base_date = datetime(2024, 1, 1, 12, 0, 0)
+    _create_signal_with_result(
+        db_session,
+        signal_id="sig-low-1",
+        risk_profile=RiskProfile.LOW,
+        closed_at=base_date,
+        net_pnl_usd=150.0,
+        net_pnl_pct=3.0,
+        position_size_usd=1000.0,
+    )
+    _create_signal_with_result(
+        db_session,
+        signal_id="sig-low-2",
+        risk_profile=RiskProfile.LOW,
+        closed_at=base_date + timedelta(hours=2),
+        net_pnl_usd=50.0,
+        net_pnl_pct=1.0,
+        position_size_usd=800.0,
+    )
+    _create_signal_with_result(
+        db_session,
+        signal_id="sig-med-1",
+        risk_profile=RiskProfile.MEDIUM,
+        closed_at=base_date,
+        net_pnl_usd=-20.0,
+        net_pnl_pct=-0.5,
+        position_size_usd=1200.0,
+    )
+    _create_signal_with_result(
+        db_session,
+        signal_id="sig-high-1",
+        risk_profile=RiskProfile.HIGH,
+        closed_at=base_date + timedelta(days=1),
+        net_pnl_usd=200.0,
+        net_pnl_pct=4.0,
+        position_size_usd=1500.0,
+    )
+
+    # Query exposures and assert aggregation on the inserted dataset.
+    response = await system.get_system_exposure(db=db_session)
+
+    assert response[0].exposure_usd == pytest.approx(1800.0)
+    assert response[1].exposure_usd == pytest.approx(1200.0)
+    assert response[2].exposure_usd == pytest.approx(1500.0)
+    assert stored_cache["system:exposure"]["ttl"] == ANALYTICS_CACHE_TTL_SECONDS
+
+
+@pytest.mark.asyncio
+async def test_get_system_exposure_returns_cached(monkeypatch, db_session: Session):
+    cached_payload = [
+        {"date": "2024-02-01", "risk_profile": "low", "exposure_usd": 999.0}
+    ]
+
+    monkeypatch.setattr(cache, "get_cached_json", lambda key: cached_payload)
+
+    set_called = False
+
+    def _fake_set(*args, **kwargs):
+        nonlocal set_called
+        set_called = True
+
+    monkeypatch.setattr(cache, "set_cached_json", _fake_set)
+
+    response = await system.get_system_exposure(db=db_session)
+
+    assert len(response) == 1
+    assert response[0].risk_profile == RiskProfile.LOW
+    assert response[0].exposure_usd == pytest.approx(999.0)
+    assert set_called is False


### PR DESCRIPTION
## Summary
- add Redis-backed caching utilities and expose PnL and exposure aggregations on the system API
- extend the admin dashboard with analytics charts that consume the new endpoints
- cover aggregation logic and caching behaviour with focused API tests

## Testing
- pytest tests/test_system_aggregations.py

------
https://chatgpt.com/codex/tasks/task_e_68e27b493e14832db139b249215d16cb