### PR TITLE
Add authentication router with JWT security

### DIFF
--- a/apps/api/main.py
+++ b/apps/api/main.py
@@ -1,7 +1,7 @@
 from fastapi import FastAPI, WebSocket, WebSocketDisconnect
 from fastapi.middleware.cors import CORSMiddleware
 from apps.api.config import settings
-from apps.api.routers import signals, backtest, backfill, train, settings as settings_router, system
+from apps.api.routers import auth, signals, backtest, backfill, train, settings as settings_router, system
 import logging
 
 logging.basicConfig(level=logging.INFO)
@@ -23,6 +23,7 @@ app.add_middleware(
 )
 
 # Include routers
+app.include_router(auth.router, prefix=f"{settings.API_V1_PREFIX}/auth", tags=["Auth"])
 app.include_router(signals.router, prefix=f"{settings.API_V1_PREFIX}/signals", tags=["Signals"])
 app.include_router(backtest.router, prefix=f"{settings.API_V1_PREFIX}/backtest", tags=["Backtest"])
 app.include_router(backfill.router, prefix=f"{settings.API_V1_PREFIX}/backfill", tags=["Backfill"])

--- a/apps/api/routers/auth.py
+++ b/apps/api/routers/auth.py
@@ -1,0 +1,82 @@
+from datetime import datetime
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from pydantic import BaseModel
+from sqlalchemy import or_
+from sqlalchemy.orm import Session
+
+from apps.api.db import get_db
+from apps.api.db.models import User
+from apps.api.security import authenticate_user, create_access_token, get_password_hash
+
+router = APIRouter()
+
+
+class UserCreate(BaseModel):
+    username: str
+    email: str
+    password: str
+
+
+class LoginRequest(BaseModel):
+    username: str
+    password: str
+
+
+class UserResponse(BaseModel):
+    id: int
+    username: str
+    email: str
+    is_active: bool
+    is_admin: bool
+
+    class Config:
+        from_attributes = True
+
+
+class AuthResponse(BaseModel):
+    access_token: str
+    token_type: str
+    user: UserResponse
+
+
+@router.post("/register", response_model=AuthResponse, status_code=status.HTTP_201_CREATED)
+def register_user(payload: UserCreate, db: Session = Depends(get_db)) -> AuthResponse:
+    existing_user = (
+        db.query(User)
+        .filter(or_(User.username == payload.username, User.email == payload.email))
+        .first()
+    )
+    if existing_user:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="User already exists")
+
+    user = User(
+        username=payload.username,
+        email=payload.email,
+        hashed_password=get_password_hash(payload.password),
+    )
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+
+    token = create_access_token({"sub": str(user.id), "username": user.username})
+    return AuthResponse(access_token=token, token_type="bearer", user=user)
+
+
+@router.post("/login", response_model=AuthResponse)
+def login(payload: LoginRequest, db: Session = Depends(get_db)) -> AuthResponse:
+    user = authenticate_user(db, payload.username, payload.password)
+    if not user:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Incorrect username or password",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+
+    user.last_login = datetime.utcnow()
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+
+    token = create_access_token({"sub": str(user.id), "username": user.username})
+    return AuthResponse(access_token=token, token_type="bearer", user=user)

--- a/apps/api/routers/backfill.py
+++ b/apps/api/routers/backfill.py
@@ -4,12 +4,13 @@ from pydantic import BaseModel
 from typing import Optional
 from datetime import datetime
 from apps.api.db import get_db
+from apps.api.security import get_current_user
 from apps.api.db.models import BackfillJob, TimeFrame
 from apps.ml.backfill import BackfillService
 import logging
 
 logger = logging.getLogger(__name__)
-router = APIRouter()
+router = APIRouter(dependencies=[Depends(get_current_user)])
 
 
 class BackfillRequest(BaseModel):

--- a/apps/api/routers/signals.py
+++ b/apps/api/routers/signals.py
@@ -6,9 +6,10 @@ from typing import List, Optional
 from datetime import datetime, timedelta
 from apps.api.db import get_async_db, get_db
 from apps.api.db.models import Signal, RiskProfile, SignalStatus, TradeResult
+from apps.api.security import get_current_user
 from pydantic import BaseModel
 
-router = APIRouter()
+router = APIRouter(dependencies=[Depends(get_current_user)])
 
 
 class SignalResponse(BaseModel):

--- a/apps/api/routers/train.py
+++ b/apps/api/routers/train.py
@@ -3,13 +3,14 @@ from pydantic import BaseModel
 from typing import Optional, List, Dict, Any
 from sqlalchemy.orm import Session
 from apps.api.db import get_db
+from apps.api.security import get_current_user
 from celery.result import AsyncResult
 from apps.ml.worker import celery_app
 from apps.ml.model_registry import ModelRegistry
 from apps.ml.performance_tracker import PerformanceTracker
 from datetime import datetime
 
-router = APIRouter()
+router = APIRouter(dependencies=[Depends(get_current_user)])
 
 
 class TrainRequest(BaseModel):

--- a/apps/api/security/__init__.py
+++ b/apps/api/security/__init__.py
@@ -1,0 +1,17 @@
+from .auth import (
+    authenticate_user,
+    create_access_token,
+    get_current_user,
+    get_password_hash,
+    oauth2_scheme,
+    verify_password,
+)
+
+__all__ = [
+    "authenticate_user",
+    "create_access_token",
+    "get_current_user",
+    "get_password_hash",
+    "oauth2_scheme",
+    "verify_password",
+]

--- a/apps/api/security/auth.py
+++ b/apps/api/security/auth.py
@@ -1,0 +1,86 @@
+from datetime import datetime, timedelta
+from typing import Any, Dict, Optional
+
+import bcrypt
+from fastapi import Depends, HTTPException, status
+from fastapi.security import OAuth2PasswordBearer
+from jose import JWTError, jwt
+from sqlalchemy import or_
+from sqlalchemy.orm import Session
+
+from apps.api.config import settings
+from apps.api.db import get_db
+from apps.api.db.models import User
+
+
+oauth2_scheme = OAuth2PasswordBearer(tokenUrl=f"{settings.API_V1_PREFIX}/auth/login")
+
+
+def verify_password(plain_password: str, hashed_password: str) -> bool:
+    return bcrypt.checkpw(plain_password.encode("utf-8"), hashed_password.encode("utf-8"))
+
+
+def get_password_hash(password: str) -> str:
+    return bcrypt.hashpw(password.encode("utf-8"), bcrypt.gensalt()).decode("utf-8")
+
+
+def create_access_token(data: Dict[str, Any], expires_delta: Optional[timedelta] = None) -> str:
+    to_encode = data.copy()
+    expire = datetime.utcnow() + (
+        expires_delta or timedelta(minutes=settings.ACCESS_TOKEN_EXPIRE_MINUTES)
+    )
+    to_encode.update({"exp": expire})
+    encoded_jwt = jwt.encode(to_encode, settings.SECRET_KEY, algorithm=settings.ALGORITHM)
+    return encoded_jwt
+
+
+def authenticate_user(db: Session, username_or_email: str, password: str) -> Optional[User]:
+    user = (
+        db.query(User)
+        .filter(or_(User.username == username_or_email, User.email == username_or_email))
+        .first()
+    )
+    if not user or not verify_password(password, user.hashed_password):
+        return None
+    if not user.is_active:
+        return None
+    return user
+
+
+async def get_current_user(
+    token: str = Depends(oauth2_scheme), db: Session = Depends(get_db)
+) -> User:
+    credentials_exception = HTTPException(
+        status_code=status.HTTP_401_UNAUTHORIZED,
+        detail="Could not validate credentials",
+        headers={"WWW-Authenticate": "Bearer"},
+    )
+    try:
+        payload = jwt.decode(token, settings.SECRET_KEY, algorithms=[settings.ALGORITHM])
+        user_id: Optional[str] = payload.get("sub")
+        if user_id is None:
+            raise credentials_exception
+    except JWTError as exc:  # pragma: no cover - defensive
+        raise credentials_exception from exc
+
+    try:
+        user_id_int = int(user_id)
+    except (TypeError, ValueError) as exc:
+        raise credentials_exception from exc
+
+    user = db.query(User).filter(User.id == user_id_int).first()
+    if user is None:
+        raise credentials_exception
+    if not user.is_active:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Inactive user")
+    return user
+
+
+__all__ = [
+    "authenticate_user",
+    "create_access_token",
+    "get_current_user",
+    "get_password_hash",
+    "oauth2_scheme",
+    "verify_password",
+]

--- a/tests/test_auth_api.py
+++ b/tests/test_auth_api.py
@@ -1,0 +1,123 @@
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from apps.api.main import app
+from apps.api.db import Base, get_db, get_async_db
+
+
+@pytest.fixture(scope="session")
+def db_engines(tmp_path_factory):
+    db_dir = tmp_path_factory.mktemp("auth-db")
+    db_path = db_dir / "test.db"
+    engine = create_engine(f"sqlite:///{db_path}", connect_args={"check_same_thread": False})
+    SessionLocal = sessionmaker(bind=engine, autocommit=False, autoflush=False)
+
+    yield {
+        "engine": engine,
+        "SessionLocal": SessionLocal,
+        "db_path": db_path,
+        "db_dir": db_dir,
+    }
+
+    engine.dispose()
+    if db_path.exists():
+        db_path.unlink()
+    if db_dir.exists():
+        db_dir.rmdir()
+
+
+@pytest.fixture
+def client(db_engines):
+    engine = db_engines["engine"]
+    SessionLocal = db_engines["SessionLocal"]
+    Base.metadata.drop_all(bind=engine)
+    Base.metadata.create_all(bind=engine)
+
+    class AsyncSessionProxy:
+        def __init__(self, session):
+            self._session = session
+
+        async def execute(self, *args, **kwargs):
+            return self._session.execute(*args, **kwargs)
+
+        async def commit(self):
+            return self._session.commit()
+
+        async def rollback(self):
+            return self._session.rollback()
+
+        async def close(self):
+            self._session.close()
+
+        def __getattr__(self, item):
+            return getattr(self._session, item)
+
+    def override_get_db():
+        db = SessionLocal()
+        try:
+            yield db
+        finally:
+            db.close()
+
+    async def override_get_async_db():
+        db = SessionLocal()
+        proxy = AsyncSessionProxy(db)
+        try:
+            yield proxy
+        finally:
+            db.close()
+    app.dependency_overrides[get_db] = override_get_db
+    app.dependency_overrides[get_async_db] = override_get_async_db
+
+    with TestClient(app) as test_client:
+        yield test_client
+
+    app.dependency_overrides.clear()
+
+
+def test_register_and_login_flow(client):
+    payload = {
+        "username": "testuser",
+        "email": "testuser@example.com",
+        "password": "supersecret",
+    }
+
+    response = client.post("/api/v1/auth/register", json=payload)
+    assert response.status_code == 201
+    register_data = response.json()
+    assert register_data["user"]["username"] == payload["username"]
+    assert register_data["token_type"] == "bearer"
+
+    response = client.post(
+        "/api/v1/auth/login",
+        json={"username": payload["username"], "password": payload["password"]},
+    )
+    assert response.status_code == 200
+    login_data = response.json()
+    assert login_data["user"]["email"] == payload["email"]
+    assert "access_token" in login_data
+
+
+def test_protected_routes_require_authentication(client):
+    response = client.get("/api/v1/signals/live")
+    assert response.status_code == 401
+
+    register_response = client.post(
+        "/api/v1/auth/register",
+        json={
+            "username": "alice",
+            "email": "alice@example.com",
+            "password": "password123",
+        },
+    )
+    assert register_response.status_code == 201
+    token = register_response.json()["access_token"]
+
+    response = client.get(
+        "/api/v1/signals/live",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert response.status_code == 200
+    assert response.json() == []


### PR DESCRIPTION
## Summary
- implement a security module that provides bcrypt password hashing, JWT issuance, and current-user resolution
- add an auth router with registration and login endpoints and require authentication on signals, train, and backfill routes
- cover the new authentication flow with API tests that validate login, registration, and protected route access

## Testing
- pytest tests/test_auth_api.py

------
https://chatgpt.com/codex/tasks/task_e_68e27b59696c832d903eac175d06148e