### PR TITLE
Add AI summary generation for signals

### DIFF
--- a/apps/api/config.py
+++ b/apps/api/config.py
@@ -33,6 +33,16 @@ class Settings(BaseSettings):
     MIN_NET_PROFIT_PCT: float = 2.0
     DEFAULT_LOOKBACK_YEARS: int = 4
 
+    # LLM / Summaries
+    LLM_PROVIDER: str = "openai"
+    LLM_MODEL: str = "gpt-4o-mini"
+    LLM_API_KEY: str = ""
+    LLM_MAX_TOKENS: int = 512
+    LLM_SUMMARY_TEMPLATE: str = (
+        "Signal $signal_id on $symbol recommends a $side position at $entry_price "
+        "with expected profit of $expected_net_profit_pct% and confidence $confidence%."
+    )
+
     # Costs
     MAKER_FEE_BPS: float = 2.0
     TAKER_FEE_BPS: float = 5.0

--- a/apps/ml/summaries.py
+++ b/apps/ml/summaries.py
@@ -1,0 +1,151 @@
+"""Utilities for generating AI-powered summaries for trading signals."""
+
+import logging
+from dataclasses import dataclass
+from string import Template
+from typing import Any, Dict, Optional
+
+from apps.api.config import settings
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class LLMClient:
+    """Simple client wrapper describing the configured LLM provider.
+
+    The default implementation simply echoes the rendered prompt. This keeps the
+    system functional without an external dependency while providing a clear
+    extension point for integrating a real LLM provider in the future.
+    """
+
+    provider: str
+    api_key: str
+    model: str
+    max_tokens: int
+
+    @property
+    def is_configured(self) -> bool:
+        """Return True when an API key is present."""
+
+        return bool(self.api_key)
+
+    def generate(self, prompt: str, *, context: Optional[Dict[str, Any]] = None) -> str:
+        """Generate a summary for the supplied prompt.
+
+        The base implementation just echoes the prompt. Downstream projects can
+        subclass :class:`LLMClient` and override :meth:`generate` to call the
+        provider-specific API.
+        """
+
+        logger.debug(
+            "LLM client for provider %s is operating in echo mode; returning prompt.",
+            self.provider,
+        )
+        return prompt
+
+
+def _build_template_context(
+    signal_data: Dict[str, Any],
+    model_info: Optional[Dict[str, Any]] = None,
+    inference_metadata: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
+    """Build a context dictionary used for summary templating."""
+
+    model_info = model_info or {}
+    inference_metadata = inference_metadata or {}
+
+    def _coerce_side(value: Any) -> str:
+        if hasattr(value, "value"):
+            return str(value.value)
+        return str(value) if value is not None else ""
+
+    def _fmt_float(value: Any, precision: int = 2) -> str:
+        try:
+            return f"{float(value):.{precision}f}"
+        except (TypeError, ValueError):
+            return ""
+
+    def _fmt_pct(value: Any, precision: int = 2) -> str:
+        try:
+            return f"{float(value):.{precision}f}"
+        except (TypeError, ValueError):
+            return ""
+
+    context: Dict[str, Any] = {
+        "signal_id": signal_data.get("signal_id", ""),
+        "symbol": signal_data.get("symbol", ""),
+        "side": _coerce_side(signal_data.get("side")),
+        "entry_price": _fmt_float(signal_data.get("entry_price")),
+        "tp1_price": _fmt_float(signal_data.get("tp1_price")),
+        "tp2_price": _fmt_float(signal_data.get("tp2_price")),
+        "tp3_price": _fmt_float(signal_data.get("tp3_price")),
+        "sl_price": _fmt_float(signal_data.get("sl_price")),
+        "confidence": _fmt_pct(signal_data.get("confidence")),
+        "expected_net_profit_pct": _fmt_pct(signal_data.get("expected_net_profit_pct")),
+        "risk_reward_ratio": _fmt_float(signal_data.get("risk_reward_ratio")),
+        "model_id": model_info.get("model_id", signal_data.get("model_id", "")),
+        "model_version": model_info.get("version", signal_data.get("model_version", "")),
+        "timeframe": signal_data.get("timeframe") or inference_metadata.get("timeframe", ""),
+    }
+
+    return context
+
+
+def _render_template(template_text: str, context: Dict[str, Any]) -> str:
+    template = Template(template_text)
+    return template.safe_substitute(context)
+
+
+def get_default_llm_client() -> Optional[LLMClient]:
+    """Create a default LLM client based on configuration.
+
+    Returns ``None`` when no API key is configured so that callers can fall back
+    to deterministic templated summaries.
+    """
+
+    client = LLMClient(
+        provider=settings.LLM_PROVIDER,
+        api_key=settings.LLM_API_KEY,
+        model=settings.LLM_MODEL,
+        max_tokens=settings.LLM_MAX_TOKENS,
+    )
+    if not client.is_configured:
+        return None
+    return client
+
+
+def generate_signal_summary(
+    signal_data: Dict[str, Any],
+    model_info: Optional[Dict[str, Any]] = None,
+    inference_metadata: Optional[Dict[str, Any]] = None,
+    *,
+    client: Optional[LLMClient] = None,
+    template: Optional[str] = None,
+) -> Optional[str]:
+    """Generate an explanatory summary for a signal.
+
+    The function first renders the configured template to build a concise prompt
+    describing the signal. When an LLM client is configured it is used to
+    generate an enriched summary, otherwise the rendered template is returned.
+    Any exception raised by downstream providers is caught and logged so signal
+    generation can proceed safely.
+    """
+
+    template_text = template or settings.LLM_SUMMARY_TEMPLATE
+    context = _build_template_context(signal_data, model_info, inference_metadata)
+
+    prompt = _render_template(template_text, context)
+
+    summary_client = client if client is not None else get_default_llm_client()
+
+    if summary_client is None:
+        return prompt
+
+    try:
+        summary = summary_client.generate(prompt, context=context)
+    except Exception:  # pragma: no cover - defensive logging
+        logger.exception("Failed to generate LLM summary; falling back to template output.")
+        return prompt
+
+    return summary or prompt

--- a/tests/test_signal_engine_pipeline.py
+++ b/tests/test_signal_engine_pipeline.py
@@ -299,6 +299,139 @@ def test_generate_signals_task_returns_statistics(monkeypatch):
     engine.dispose()
 
 
+def test_generate_signals_task_includes_ai_summary(monkeypatch):
+    SessionLocal, engine = create_sqlite_session()
+    session = SessionLocal()
+    insert_mock_ohlcv(session)
+
+    registry_record = ModelRegistryRecord(
+        model_id='model123',
+        symbol='BTC/USDT',
+        timeframe=TimeFrame.M15,
+        model_type='ensemble',
+        version='v1',
+        train_start=datetime.utcnow() - timedelta(days=200),
+        train_end=datetime.utcnow() - timedelta(days=60),
+        oos_start=datetime.utcnow() - timedelta(days=60),
+        oos_end=datetime.utcnow() - timedelta(days=1),
+        hyperparameters={}
+    )
+    session.add(registry_record)
+    session.commit()
+    session.close()
+
+    def session_factory():
+        return SessionLocal()
+
+    monkeypatch.setattr('apps.ml.worker.SessionLocal', session_factory)
+
+    class StubRegistry:
+        def __init__(self):
+            self.index = {
+                'deployments': {
+                    'BTC_USDT_15m_production': {
+                        'symbol': 'BTC/USDT',
+                        'timeframe': '15m',
+                        'environment': 'production',
+                        'model_id': 'model123',
+                        'version': 'v1',
+                        'path': 'unused'
+                    }
+                }
+            }
+
+        def get_deployed_model(self, symbol, timeframe, environment='production'):
+            return {
+                'symbol': symbol,
+                'timeframe': timeframe,
+                'environment': environment,
+                'model_id': 'model123',
+                'version': 'v1',
+                'path': 'unused'
+            }
+
+    generator = SignalGenerator()
+
+    class StubSignalEngine:
+        def __init__(self, db, registry=None, **kwargs):
+            self.db = db
+            self.registry = registry
+
+        def generate_for_deployment(self, symbol, timeframe, environment='production', **kwargs):
+            timestamp = datetime.utcnow()
+            signal = generator.generate_signal(
+                symbol=symbol,
+                side=Side.LONG,
+                entry_price=52000.0,
+                atr=1500.0,
+                risk_profile=RiskProfile.MEDIUM,
+                capital_usd=1000.0,
+                confidence=0.75,
+                timestamp=timestamp
+            )
+
+            if not signal:
+                return None
+
+            signal['model_id'] = 'model123'
+            signal['model_version'] = 'v1'
+
+            return SimpleNamespace(
+                signal=signal,
+                model_info={
+                    'model_id': 'model123',
+                    'version': 'v1',
+                    'path': 'unused'
+                },
+                risk_filters={
+                    'spread': True,
+                    'liquidity': True,
+                    'profit': True,
+                    'correlation': True,
+                    'confidence': True,
+                    'position_limit': True
+                },
+                inference_metadata={'probability': 0.75, 'confidence': 0.75, 'side': 'long', 'timestamp': timestamp},
+                accepted=True
+            )
+
+    monkeypatch.setattr('apps.ml.worker.ModelRegistry', lambda: StubRegistry())
+    monkeypatch.setattr('apps.ml.worker.SignalEngine', StubSignalEngine)
+
+    summary_calls = []
+
+    def fake_generate_summary(signal_data, model_info=None, inference_metadata=None):
+        summary_calls.append({
+            'signal_id': signal_data.get('signal_id'),
+            'model_id': model_info.get('model_id') if model_info else None
+        })
+        return "Mock summary"
+
+    monkeypatch.setattr('apps.ml.worker.generate_signal_summary', fake_generate_summary)
+
+    broadcasts = []
+
+    async def fake_broadcast(message):
+        broadcasts.append(message)
+
+    monkeypatch.setattr('apps.api.main.manager.broadcast', fake_broadcast)
+
+    result = generate_signals_task.run()
+
+    assert result['signals_generated'] == 1
+    assert summary_calls and summary_calls[0]['signal_id']
+
+    session = SessionLocal()
+    stored_signals = session.query(Signal).all()
+    assert len(stored_signals) == 1
+    assert stored_signals[0].ai_summary == "Mock summary"
+    session.close()
+
+    assert broadcasts
+    assert broadcasts[0]['data']['ai_summary'] == "Mock summary"
+
+    engine.dispose()
+
 def test_generate_signals_task_skips_when_position_limit_reached(monkeypatch):
     SessionLocal, engine = create_sqlite_session()
     session = SessionLocal()


### PR DESCRIPTION
## Summary
- add configuration for LLM-driven signal summaries and introduce a helper module to render them
- call the summary generator during signal creation, persist the result, and include it in broadcast payloads
- cover the new behaviour with a worker test that mocks the summary generator

## Testing
- pytest tests/test_signal_engine_pipeline.py::test_generate_signals_task_includes_ai_summary

------
https://chatgpt.com/codex/tasks/task_e_68e27b60c40c832da9958416e7515943