### PR TITLE
Add trailing stop activation handling

### DIFF
--- a/apps/ml/signal_engine.py
+++ b/apps/ml/signal_engine.py
@@ -553,6 +553,14 @@ class SignalEngine:
 
         signal['model_id'] = deployment.get('model_id')
         signal['model_version'] = deployment.get('version')
+        signal['trailing_stop'] = {
+            'enabled': True,
+            'activation_condition': 'tp1_hit',
+            'atr_value': float(atr),
+            'breakeven_offset_multiplier': 0.5,
+            'trail_multiplier': 1.0,
+            'atr_distance': float(atr * 0.5)
+        }
 
         return SignalInferenceResult(
             signal=signal,


### PR DESCRIPTION
## Summary
- include trailing stop configuration metadata in generated signal payloads
- add worker utilities and Celery task to apply trailing stops and persist trade result updates
- extend signal engine tests with trailing stop activation coverage

## Testing
- pytest tests/test_signal_engine_pipeline.py

------
https://chatgpt.com/codex/tasks/task_e_68e27b5123f4832dbb2f532b6a92e49e