### PR TITLE
Capture signal rejection reasons

### DIFF
--- a/apps/api/db/models.py
+++ b/apps/api/db/models.py
@@ -306,6 +306,21 @@ class Signal(Base):
     trade_results = relationship("TradeResult", back_populates="signal")
 
 
+class SignalRejection(Base):
+    __tablename__ = "signal_rejections"
+
+    id = Column(Integer, primary_key=True, index=True)
+    symbol = Column(String(20), nullable=False, index=True)
+    timeframe = Column(String(20), nullable=False)
+    environment = Column(String(20), nullable=False, default="production")
+    model_id = Column(String(50))
+    risk_profile = Column(Enum(RiskProfile))
+    failed_filters = Column(JSON, nullable=False)
+    rejection_reason = Column(Text, nullable=False)
+    inference_metadata = Column(JSON)
+    created_at = Column(DateTime, default=datetime.utcnow, nullable=False)
+
+
 class TradeResult(Base):
     __tablename__ = "trade_results"
 

--- a/apps/ml/worker.py
+++ b/apps/ml/worker.py
@@ -1,7 +1,7 @@
 from celery import Celery
 from apps.api.config import settings
 from apps.api.db.session import SessionLocal
-from apps.api.db.models import OHLCV, Signal, SignalStatus, RiskProfile, Side
+from apps.api.db.models import OHLCV, Signal, SignalStatus, RiskProfile, Side, SignalRejection
 from apps.ml.backfill import BackfillService
 from apps.ml.training import train_model_pipeline
 from apps.ml.model_registry import ModelRegistry
@@ -235,12 +235,14 @@ def generate_signals_task():
 
             processed_deployments += 1
 
+            selected_risk_profile = RiskProfile.MEDIUM
+
             try:
                 result = engine.generate_for_deployment(
                     symbol=symbol,
                     timeframe=timeframe,
                     environment=environment,
-                    risk_profile=RiskProfile.MEDIUM,
+                    risk_profile=selected_risk_profile,
                     capital_usd=1000.0
                 )
             except Exception as exc:
@@ -253,6 +255,41 @@ def generate_signals_task():
                 summary['skipped'] += 1
                 if result and not result.accepted:
                     skipped_filters += 1
+                    rejection_reasons = result.rejection_reasons or []
+                    reason_text = (
+                        "Failed risk filters: " + ", ".join(rejection_reasons)
+                        if rejection_reasons
+                        else "Signal rejected by risk filters"
+                    )
+                    metadata = dict(result.inference_metadata or {})
+                    timestamp = metadata.get('timestamp')
+                    if timestamp is not None:
+                        if hasattr(timestamp, 'isoformat'):
+                            metadata['timestamp'] = timestamp.isoformat()
+                        else:
+                            metadata['timestamp'] = str(timestamp)
+                    timeframe_value = timeframe.value if hasattr(timeframe, 'value') else str(timeframe)
+                    rejection_record = SignalRejection(
+                        symbol=symbol,
+                        timeframe=timeframe_value,
+                        environment=environment,
+                        model_id=(result.model_info or {}).get('model_id') if result.model_info else None,
+                        risk_profile=selected_risk_profile,
+                        failed_filters=rejection_reasons,
+                        rejection_reason=reason_text,
+                        inference_metadata=metadata
+                    )
+                    try:
+                        db.add(rejection_record)
+                        db.commit()
+                    except Exception as exc:
+                        logger.error(
+                            "Failed to persist rejection for %s %s: %s",
+                            symbol,
+                            timeframe_value,
+                            exc
+                        )
+                        db.rollback()
                 continue
 
             signal_data = result.signal


### PR DESCRIPTION
## Summary
- extend `SignalInferenceResult` with rejection reasons and track failed risk filters in the signal engine
- persist rejected signal information in a dedicated `signal_rejections` table from the worker
- add an integration test that forces a filter failure and asserts the recorded rejection text

## Testing
- pytest tests/test_signal_engine_pipeline.py


------
https://chatgpt.com/codex/tasks/task_e_68e27b5fc604832d9e422f322575a9ab