### PR TITLE
Add tracked pair configuration management

### DIFF
--- a/apps/api/db/models.py
+++ b/apps/api/db/models.py
@@ -43,6 +43,22 @@ class Side(str, PyEnum):
 # MARKET DATA
 # ============================================================================
 
+class TrackedPair(Base):
+    __tablename__ = "tracked_pairs"
+    __table_args__ = (
+        UniqueConstraint("symbol", "timeframe", name="uq_tracked_pairs_symbol_timeframe"),
+        Index("idx_tracked_pairs_symbol", "symbol"),
+        Index("idx_tracked_pairs_active", "is_active"),
+    )
+
+    id = Column(Integer, primary_key=True, index=True)
+    symbol = Column(String(20), nullable=False, index=True)
+    timeframe = Column(Enum(TimeFrame), nullable=False)
+    is_active = Column(Boolean, default=True, nullable=False, index=True)
+    created_at = Column(DateTime, default=datetime.utcnow, nullable=False)
+    updated_at = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
+
+
 class OHLCV(Base):
     __tablename__ = "ohlcv"
     __table_args__ = (

--- a/apps/common/tracked_pairs.py
+++ b/apps/common/tracked_pairs.py
@@ -1,0 +1,156 @@
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from typing import List, Optional
+
+from sqlalchemy.orm import Session
+
+from apps.api.db.models import SystemConfig, TimeFrame, TrackedPair
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class TrackedPairConfig:
+    symbol: str
+    timeframe: TimeFrame
+
+
+DEFAULT_TRACKED_PAIRS: List[TrackedPairConfig] = [
+    TrackedPairConfig("BTC/USDT", TimeFrame.M15),
+    TrackedPairConfig("ETH/USDT", TimeFrame.M15),
+    TrackedPairConfig("BNB/USDT", TimeFrame.M15),
+    TrackedPairConfig("XRP/USDT", TimeFrame.M15),
+    TrackedPairConfig("ADA/USDT", TimeFrame.M15),
+    TrackedPairConfig("SOL/USDT", TimeFrame.M15),
+    TrackedPairConfig("DOGE/USDT", TimeFrame.M15),
+    TrackedPairConfig("POL/USDT", TimeFrame.M15),
+    TrackedPairConfig("DOT/USDT", TimeFrame.M15),
+    TrackedPairConfig("AVAX/USDT", TimeFrame.M15),
+    TrackedPairConfig("LINK/USDT", TimeFrame.M15),
+    TrackedPairConfig("UNI/USDT", TimeFrame.M15),
+]
+
+_CACHE_TTL_SECONDS = 300
+_CACHE_STATE = {
+    "pairs": None,
+    "version": None,
+    "expires_at": None,
+}
+_VERSION_KEY = "tracked_pairs_version"
+
+
+def invalidate_tracked_pairs_cache() -> None:
+    """Clear the in-process cache for tracked pairs."""
+
+    _CACHE_STATE["pairs"] = None
+    _CACHE_STATE["version"] = None
+    _CACHE_STATE["expires_at"] = None
+
+
+def _parse_version(value: Optional[object]) -> Optional[str]:
+    if value is None:
+        return None
+    if isinstance(value, dict):
+        raw_value = value.get("version")
+        if raw_value is None:
+            return None
+        return str(raw_value)
+    return str(value)
+
+
+def _load_version(db: Session) -> Optional[str]:
+    entry = (
+        db.query(SystemConfig)
+        .filter(SystemConfig.key == _VERSION_KEY)
+        .first()
+    )
+    if entry is None:
+        return None
+    return _parse_version(entry.value)
+
+
+def bump_tracked_pairs_version(db: Session, *, commit: bool = False) -> str:
+    """Increment the configuration version for tracked pairs.
+
+    Returns the new version string.
+    """
+
+    version_value = datetime.utcnow().isoformat()
+    payload = {"version": version_value}
+
+    entry = (
+        db.query(SystemConfig)
+        .filter(SystemConfig.key == _VERSION_KEY)
+        .first()
+    )
+
+    if entry is None:
+        entry = SystemConfig(
+            key=_VERSION_KEY,
+            value=payload,
+            description="Version marker for tracked pairs configuration",
+        )
+        db.add(entry)
+    else:
+        entry.value = payload
+
+    if commit:
+        db.commit()
+    else:
+        db.flush()
+
+    return version_value
+
+
+def get_tracked_pairs(db: Session, *, use_cache: bool = True) -> List[TrackedPairConfig]:
+    """Return the list of active tracked pairs with optional caching."""
+
+    now = datetime.utcnow()
+    version = _load_version(db)
+
+    if use_cache:
+        cached_pairs = _CACHE_STATE.get("pairs")
+        cached_version = _CACHE_STATE.get("version")
+        expires_at = _CACHE_STATE.get("expires_at")
+
+        if (
+            cached_pairs is not None
+            and cached_version == version
+            and expires_at is not None
+            and now < expires_at
+        ):
+            return cached_pairs
+
+    try:
+        rows: List[TrackedPair] = (
+            db.query(TrackedPair)
+            .filter(TrackedPair.is_active.is_(True))
+            .order_by(TrackedPair.symbol.asc())
+            .all()
+        )
+    except Exception as exc:  # pragma: no cover - defensive logging
+        logger.error("Failed to load tracked pairs from database: %s", exc)
+        rows = []
+
+    if not rows:
+        pairs = list(DEFAULT_TRACKED_PAIRS)
+    else:
+        pairs = [
+            TrackedPairConfig(
+                symbol=row.symbol,
+                timeframe=row.timeframe
+                if isinstance(row.timeframe, TimeFrame)
+                else TimeFrame(row.timeframe),
+            )
+            for row in rows
+        ]
+
+    if use_cache:
+        _CACHE_STATE["pairs"] = pairs
+        _CACHE_STATE["version"] = version
+        _CACHE_STATE["expires_at"] = now + timedelta(seconds=_CACHE_TTL_SECONDS)
+
+    return pairs

--- a/migrations/versions/1f4f7c0b4a65_add_tracked_pairs_table.py
+++ b/migrations/versions/1f4f7c0b4a65_add_tracked_pairs_table.py
@@ -1,0 +1,120 @@
+"""Add tracked pairs table
+
+Revision ID: 1f4f7c0b4a65
+Revises: 93d8353d4348
+Create Date: 2024-04-22 00:00:00.000000
+
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+revision: str = "1f4f7c0b4a65"
+down_revision: Union[str, None] = "93d8353d4348"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+TRACKED_PAIR_DEFAULTS = [
+    ("BTC/USDT", "15m"),
+    ("ETH/USDT", "15m"),
+    ("BNB/USDT", "15m"),
+    ("XRP/USDT", "15m"),
+    ("ADA/USDT", "15m"),
+    ("SOL/USDT", "15m"),
+    ("DOGE/USDT", "15m"),
+    ("POL/USDT", "15m"),
+    ("DOT/USDT", "15m"),
+    ("AVAX/USDT", "15m"),
+    ("LINK/USDT", "15m"),
+    ("UNI/USDT", "15m"),
+]
+
+
+def upgrade() -> None:
+    timeframe_enum = sa.Enum(
+        "M1", "M5", "M15", "H1", "H4", "D1",
+        name="timeframe",
+        create_type=False,
+    )
+
+    op.create_table(
+        "tracked_pairs",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("symbol", sa.String(length=20), nullable=False),
+        sa.Column("timeframe", timeframe_enum, nullable=False),
+        sa.Column("is_active", sa.Boolean(), nullable=False, server_default=sa.true()),
+        sa.Column("created_at", sa.DateTime(), nullable=False, server_default=sa.text("now()")),
+        sa.Column("updated_at", sa.DateTime(), nullable=True, server_default=sa.text("now()")),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("symbol", "timeframe", name="uq_tracked_pairs_symbol_timeframe"),
+    )
+    op.create_index(op.f("ix_tracked_pairs_id"), "tracked_pairs", ["id"], unique=False)
+    op.create_index("idx_tracked_pairs_symbol", "tracked_pairs", ["symbol"], unique=False)
+    op.create_index("idx_tracked_pairs_active", "tracked_pairs", ["is_active"], unique=False)
+
+    tracked_pairs_table = sa.table(
+        "tracked_pairs",
+        sa.column("symbol", sa.String(length=20)),
+        sa.column("timeframe", timeframe_enum),
+        sa.column("is_active", sa.Boolean()),
+        sa.column("created_at", sa.DateTime()),
+        sa.column("updated_at", sa.DateTime()),
+    )
+
+    now = datetime.utcnow()
+    op.bulk_insert(
+        tracked_pairs_table,
+        [
+            {
+                "symbol": symbol,
+                "timeframe": timeframe,
+                "is_active": True,
+                "created_at": now,
+                "updated_at": now,
+            }
+            for symbol, timeframe in TRACKED_PAIR_DEFAULTS
+        ],
+    )
+
+    system_config_table = sa.table(
+        "system_config",
+        sa.column("key", sa.String(length=100)),
+        sa.column("value", sa.JSON()),
+        sa.column("description", sa.Text()),
+        sa.column("updated_at", sa.DateTime()),
+    )
+
+    conn = op.get_bind()
+    version_payload = {"version": datetime.utcnow().isoformat()}
+
+    insert_stmt = postgresql.insert(system_config_table).values(
+        key="tracked_pairs_version",
+        value=version_payload,
+        description="Version marker for tracked pairs configuration",
+        updated_at=datetime.utcnow(),
+    )
+    upsert_stmt = insert_stmt.on_conflict_do_update(
+        index_elements=[system_config_table.c.key],
+        set_={
+            "value": insert_stmt.excluded.value,
+            "updated_at": insert_stmt.excluded.updated_at,
+            "description": insert_stmt.excluded.description,
+        },
+    )
+    conn.execute(upsert_stmt)
+
+
+def downgrade() -> None:
+    op.execute("DELETE FROM system_config WHERE key = 'tracked_pairs_version'")
+    op.drop_index("idx_tracked_pairs_active", table_name="tracked_pairs")
+    op.drop_index("idx_tracked_pairs_symbol", table_name="tracked_pairs")
+    op.drop_index(op.f("ix_tracked_pairs_id"), table_name="tracked_pairs")
+    op.drop_table("tracked_pairs")

--- a/tests/test_tracked_pairs_dynamic.py
+++ b/tests/test_tracked_pairs_dynamic.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pandas as pd
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from apps.api.db.base import Base
+from apps.api.db import models
+from apps.common.tracked_pairs import (
+    bump_tracked_pairs_version,
+    get_tracked_pairs,
+    invalidate_tracked_pairs_cache,
+)
+from apps.ml import worker as worker_module
+
+
+@pytest.fixture
+def sqlite_sessionmaker():
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    return sessionmaker(bind=engine)
+
+
+class DummyClient:
+    def fetch_ohlcv_range(self, **_: object) -> pd.DataFrame:
+        return pd.DataFrame()
+
+    def get_earliest_timestamp(self, *_: object) -> None:
+        return None
+
+
+def test_update_task_detects_new_tracked_pair(sqlite_sessionmaker, monkeypatch):
+    Session = sqlite_sessionmaker
+
+    invalidate_tracked_pairs_cache()
+
+    created_jobs: list[tuple[str, str]] = []
+
+    class DummyBackfillService:
+        def __init__(self, db_session):
+            self.db = db_session
+            self.client = DummyClient()
+
+        def _upsert_ohlcv(self, *_: object) -> None:  # pragma: no cover - not used in this test
+            return None
+
+        def create_backfill_job(self, symbol, timeframe, start_date, end_date):  # noqa: ANN001
+            created_jobs.append((symbol, getattr(timeframe, "value", timeframe)))
+            return SimpleNamespace(job_id=f"job-{symbol}-{getattr(timeframe, 'value', timeframe)}")
+
+    class DummyExecute:
+        @staticmethod
+        def delay(_job_id: str) -> None:
+            return None
+
+    monkeypatch.setattr(worker_module, "SessionLocal", Session)
+    monkeypatch.setattr(worker_module, "BackfillService", DummyBackfillService)
+    monkeypatch.setattr(worker_module, "execute_backfill_task", DummyExecute)
+
+    # Seed initial tracked pair
+    with Session() as db:
+        pair = models.TrackedPair(
+            symbol="BTC/USDT",
+            timeframe=models.TimeFrame.M15,
+            is_active=True,
+        )
+        db.add(pair)
+        bump_tracked_pairs_version(db)
+        db.commit()
+
+    first_result = worker_module.update_latest_candles_task()
+
+    assert first_result["pairs_tracked"] == 1
+    assert any(symbol == "BTC/USDT" for symbol, _ in created_jobs)
+
+    created_jobs.clear()
+
+    # Add a new tracked pair and verify it is picked up on subsequent runs
+    with Session() as db:
+        new_pair = models.TrackedPair(
+            symbol="ETH/USDT",
+            timeframe=models.TimeFrame.M15,
+            is_active=True,
+        )
+        db.add(new_pair)
+        bump_tracked_pairs_version(db)
+        db.commit()
+
+    second_result = worker_module.update_latest_candles_task()
+
+    assert second_result["pairs_tracked"] == 2
+    assert any(symbol == "ETH/USDT" for symbol, _ in created_jobs)
+
+    # Ensure helper returns both tracked pairs without relying on cache
+    with Session() as db:
+        invalidate_tracked_pairs_cache()
+        pairs = get_tracked_pairs(db, use_cache=False)
+
+    symbols = {pair.symbol for pair in pairs}
+    assert symbols == {"BTC/USDT", "ETH/USDT"}


### PR DESCRIPTION
## Summary
- add a tracked_pairs model, migration, and shared helper to persist and cache active symbol/timeframe combinations
- update worker, backfill, and system endpoints to read tracked pairs dynamically and expose CRUD management APIs
- extend the admin dashboard to manage tracked pairs and add a regression test covering dynamic pair discovery

## Testing
- pytest tests/test_tracked_pairs_dynamic.py

------
https://chatgpt.com/codex/tasks/task_e_68e27b2dab1c832dbec624ec76faebe0